### PR TITLE
Add decrement button

### DIFF
--- a/src/counter.ts
+++ b/src/counter.ts
@@ -25,17 +25,27 @@ export class Counter {
   }
 }
 
-export function setupCounter(element: HTMLButtonElement) {
+export function setupCounter(
+  incrementEl: HTMLButtonElement,
+  decrementEl?: HTMLButtonElement
+) {
   const counter = new Counter(0);
-  
+
   const updateDisplay = () => {
-    element.innerHTML = `count is ${counter.getCount()} :)`;
+    incrementEl.innerHTML = `count is ${counter.getCount()} :)`;
   };
 
-  element.addEventListener('click', () => {
+  incrementEl.addEventListener('click', () => {
     counter.increment();
     updateDisplay();
   });
+
+  if (decrementEl) {
+    decrementEl.addEventListener('click', () => {
+      counter.decrement();
+      updateDisplay();
+    });
+  }
 
   updateDisplay();
   return counter; // Useful for testing

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
     <h1>Vite + TypeScript</h1>
     <div class="card">
       <button id="counter" style="background-color:black;" type="button"></button>
+      <button id="decrement" style="background-color:black;" type="button">decrement</button>
     </div>
     <p class="read-the-docs">
       Click on the Vite and TypeScript logos to learn more
@@ -21,6 +22,9 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   </div>
 `
 
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+setupCounter(
+  document.querySelector<HTMLButtonElement>('#counter')!,
+  document.querySelector<HTMLButtonElement>('#decrement')!
+)
 
 // adding this comment as a test.


### PR DESCRIPTION
## Summary
- add optional decrement button support to counter
- update the example HTML to show a decrement button

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6843476d4d6c832eb092904ee400749f